### PR TITLE
RECORDING_MEETING_COMPLETED clarification

### DIFF
--- a/source/includes/reference/_webhooks.md.erb
+++ b/source/includes/reference/_webhooks.md.erb
@@ -36,4 +36,4 @@ Most programming languages encode the authorization header automatically. With H
 
 Go to [Credential](https://zoom.us/developer/api/credential) page and click Enable Push Notifications.
 
-**Note:** To receive RECORDING_MEETING_COMPLETED status notifications you must also enable push notifications under the recording setting on the [Account Settings](https://zoom.us/account/setting) page.
+**Note:** To receive RECORDING_MEETING_COMPLETED status notifications you must also enable push notifications under the recording section on the [Account Settings](https://zoom.us/account/setting) page.

--- a/source/includes/reference/_webhooks.md.erb
+++ b/source/includes/reference/_webhooks.md.erb
@@ -35,3 +35,5 @@ Most programming languages encode the authorization header automatically. With H
 ## To Enable Push Notifications
 
 Go to [Credential](https://zoom.us/developer/api/credential) page and click Enable Push Notifications.
+
+**Note:** To enable RECORDING_MEETING_COMPLETED status notifications you must first enable push notifications under the recording setting on the [Account Settings](https://zoom.us/account/setting) page.

--- a/source/includes/reference/_webhooks.md.erb
+++ b/source/includes/reference/_webhooks.md.erb
@@ -36,4 +36,4 @@ Most programming languages encode the authorization header automatically. With H
 
 Go to [Credential](https://zoom.us/developer/api/credential) page and click Enable Push Notifications.
 
-**Note:** To receive RECORDING_MEETING_COMPLETED status notifications you must also enable push notifications under the recording section on the [Account Settings](https://zoom.us/account/setting) page.
+<aside class="notice">To receive RECORDING_MEETING_COMPLETED status notifications you must also enable push notifications under the recording section on the [Account Settings](https://zoom.us/account/setting) page.</aside>

--- a/source/includes/reference/_webhooks.md.erb
+++ b/source/includes/reference/_webhooks.md.erb
@@ -36,4 +36,4 @@ Most programming languages encode the authorization header automatically. With H
 
 Go to [Credential](https://zoom.us/developer/api/credential) page and click Enable Push Notifications.
 
-**Note:** To enable RECORDING_MEETING_COMPLETED status notifications you must first enable push notifications under the recording setting on the [Account Settings](https://zoom.us/account/setting) page.
+**Note:** To receive RECORDING_MEETING_COMPLETED status notifications you must also enable push notifications under the recording setting on the [Account Settings](https://zoom.us/account/setting) page.


### PR DESCRIPTION
The documentation is not clear that for the RECORDING_MEETING_COMPLETED status to be triggered  a second step has to be taken in a different settings area.