### PR TITLE
Correct security definition to indicate the API requires OAuth2 authentication

### DIFF
--- a/openapi.v2.json
+++ b/openapi.v2.json
@@ -11909,10 +11909,12 @@
     },
     "securityDefinitions": {
         "global": {
-            "type": "apiKey",
-            "name": "access_token",
-            "in": "query"
-        }
+            "type":"oauth2",
+            "tokenUrl":"https://zoom.us/oauth/token"
+            ,"authorizationUrl":"https://zoom.us/oauth/authorize"
+            ,"flow":"accessCode"
+            ,"scopes": null
+            }
     },
     "security": [
         {


### PR DESCRIPTION
This is a small change to the Swagger definition, but it allows consumers to see the API uses the OAuth2 code grant flow for its authorization, opposed to the vague 'apikey' Open API security type.